### PR TITLE
add attributes to class definitions

### DIFF
--- a/lib/phlex_custom_element_generator/cli.rb
+++ b/lib/phlex_custom_element_generator/cli.rb
@@ -59,9 +59,23 @@ module PhlexCustomElementGenerator
 
       namespaces = namespaces.split(/\s*,\s*/).reject { |str| str.to_s.chomp == "" }
 
-      ManifestReader.new(manifest: manifest_path).list_tag_names.each do |tag_name|
+      manifest = ManifestReader.new(manifest: manifest_path)
+      manifest.find_all_custom_elements.each do |tag_name, mod|
         class_name = tag_name.split(/-/).map(&:capitalize).join("")
-        component = ComponentGenerator.new(class_name: class_name, tag_name: tag_name, namespaces: namespaces)
+
+        # Symbolized attribute names
+        attributes = mod["members"]
+          .map { |member| member["attribute"] }
+          .reject { |attr| attr.to_s == "" }
+          .map { |attr| attr.gsub(/-/, "_").to_sym }
+          .sort
+
+        component = ComponentGenerator.new(
+          class_name: class_name,
+          tag_name: tag_name,
+          namespaces: namespaces,
+          attributes: attributes
+        )
         file_path = File.join(directory, tag_name.gsub(/-/, "_") + ".rb")
         puts "Writing to: #{tag_name} to #{file_path}"
         File.write(file_path, component.create)

--- a/lib/phlex_custom_element_generator/cli.rb
+++ b/lib/phlex_custom_element_generator/cli.rb
@@ -65,10 +65,9 @@ module PhlexCustomElementGenerator
 
         # Symbolized attribute names
         attributes = mod["members"]
-          .map { |member| member["attribute"] }
-          .reject { |attr| attr.to_s == "" }
-          .map { |attr| attr.gsub(/-/, "_").to_sym }
-          .sort
+          .reject { |member| member["attribute"].to_s == "" }
+          .map { |member| { attr_name: member["attribute"].gsub(/-/, "_").to_sym, default_value: member["default"] } }
+          .sort_by { |member| member[:attr_name] }
 
         component = ComponentGenerator.new(
           class_name: class_name,

--- a/lib/phlex_custom_element_generator/component_generator.rb
+++ b/lib/phlex_custom_element_generator/component_generator.rb
@@ -13,9 +13,11 @@ class #{@class_name} < Phlex::HTML
   register_element :#{@tag_name}
 
   def initialize(
-    #{@attributes.length > 0 ? @attributes.join(":,\n    ") + ",\n    **attributes" : "**attributes"}
+    #{attributes_to_kwargs}
   )
-    @attributes = attributes
+    @attributes = attributes.with_defaults({
+      #{attribute_hash}
+    })
   end
 
   def view_template(&)
@@ -23,6 +25,19 @@ class #{@class_name} < Phlex::HTML
   end
 end
 RUBY
+    end
+
+
+    def attributes_to_kwargs
+      @attributes.length > 0 ?
+        @attributes.map { |attr| "#{attr[:attr_name]}: #{attr[:default_value] || "nil"}" }.join(",\n    ") + ",\n    **attributes"
+        : "**attributes"
+    end
+
+    def attribute_hash
+      @attributes.length > 0 ?
+        @attributes.map { |attr| "#{attr[:attr_name]}: #{attr[:attr_name]}" }.join(",\n      ")
+        : ""
     end
 
     def create

--- a/lib/phlex_custom_element_generator/component_generator.rb
+++ b/lib/phlex_custom_element_generator/component_generator.rb
@@ -1,17 +1,20 @@
 module PhlexCustomElementGenerator
   class ComponentGenerator
-    attr_accessor :class_name, :tag_name, :namespaces, :component_code
+    attr_accessor :class_name, :tag_name, :namespaces, :component_code, :attributes
 
-    def initialize(class_name:, tag_name:, namespaces: [])
+    def initialize(class_name:, tag_name:, namespaces: [], attributes: [])
       @class_name = class_name
       @tag_name = tag_name.gsub(/-/, "_")
       @namespaces = namespaces
+      @attributes = attributes
 
       @component_code = <<~RUBY
 class #{@class_name} < Phlex::HTML
   register_element :#{@tag_name}
 
-  def initialize(**attributes)
+  def initialize(
+    #{@attributes.length > 0 ? @attributes.join(":,\n    ") + ",\n    **attributes" : "**attributes"}
+  )
     @attributes = attributes
   end
 

--- a/lib/phlex_custom_element_generator/component_generator.rb
+++ b/lib/phlex_custom_element_generator/component_generator.rb
@@ -30,7 +30,7 @@ RUBY
 
     def attributes_to_kwargs
       @attributes.length > 0 ?
-        @attributes.map { |attr| "#{attr[:attr_name]}: #{attr[:default_value] || "nil"}" }.join(",\n    ") + ",\n    **attributes"
+        @attributes.map { |attr| "#{attr[:attr_name]}: #{(%w[undefined null].include?(attr[:default_value]) ? "nil" : attr[:default_value]) || "nil"}" }.join(",\n    ") + ",\n    **attributes"
         : "**attributes"
     end
 

--- a/lib/phlex_custom_element_generator/manifest_reader.rb
+++ b/lib/phlex_custom_element_generator/manifest_reader.rb
@@ -34,8 +34,8 @@ module PhlexCustomElementGenerator
 
           tag_name = dec["tagName"]
 
-          custom_elements[tag_name] = dec if tag_name
           dec["parent_module"] = parent_module
+          custom_elements[tag_name] = dec if tag_name
         end
       end
 

--- a/test/fixtures/component_no_namespaces.rb
+++ b/test/fixtures/component_no_namespaces.rb
@@ -1,7 +1,9 @@
 class MyElement < Phlex::HTML
   register_element :my_element
 
-  def initialize(**attributes)
+  def initialize(
+    **attributes
+  )
     @attributes = attributes
   end
 

--- a/test/fixtures/component_with_namespaces.rb
+++ b/test/fixtures/component_with_namespaces.rb
@@ -3,7 +3,9 @@ module Foo
     class MyElement < Phlex::HTML
       register_element :my_element
 
-      def initialize(**attributes)
+      def initialize(
+        **attributes
+      )
         @attributes = attributes
       end
 


### PR DESCRIPTION
Here's an example of what the ShoelaceButton looks like:

```rb
module Shoelace
  class SlButton < Phlex::HTML
    register_element :sl_button

    def initialize(
      caret: false,
      circle: false,
      disabled: false,
      download: nil,
      form: nil,
      formaction: nil,
      formenctype: nil,
      formmethod: nil,
      formnovalidate: nil,
      formtarget: nil,
      href: '',
      loading: false,
      name: '',
      outline: false,
      pill: false,
      rel: 'noreferrer noopener',
      size: 'medium',
      target: nil,
      title: '',
      type: 'button',
      value: '',
      variant: 'default',
      **attributes
    )
      @attributes = attributes.with_defaults({
        caret: caret,
        circle: circle,
        disabled: disabled,
        download: download,
        form: form,
        formaction: formaction,
        formenctype: formenctype,
        formmethod: formmethod,
        formnovalidate: formnovalidate,
        formtarget: formtarget,
        href: href,
        loading: loading,
        name: name,
        outline: outline,
        pill: pill,
        rel: rel,
        size: size,
        target: target,
        title: title,
        type: type,
        value: value,
        variant: variant
      })
    end

    def view_template(&)
      sl_button(**@attributes, &)
    end
  end
end


```